### PR TITLE
Fix 3Dconnexion imports

### DIFF
--- a/knob.html
+++ b/knob.html
@@ -14,7 +14,7 @@
 <body>
 <div id="knob"><div id="pointer"></div></div>
 <script type="module">
-import TDx from './3DconnexionJS/3dconnexion.module.min.js';
+import * as TDx from './3DconnexionJS/3dconnexion.module.min.js';
 const pointer=document.getElementById('pointer');
 let rotation=0;
 const model={

--- a/scroll.html
+++ b/scroll.html
@@ -18,7 +18,7 @@
   <p style="margin-top:150vh">End of the content.</p>
 </div>
 <script type="module">
-import TDx from './3DconnexionJS/3dconnexion.module.min.js';
+import * as TDx from './3DconnexionJS/3dconnexion.module.min.js';
 const model={
   setViewMatrix(data){
     const dy=data[13];

--- a/timeline.html
+++ b/timeline.html
@@ -17,7 +17,7 @@
   <div id="timeline"></div>
 </div>
 <script type="module">
-import TDx from './3DconnexionJS/3dconnexion.module.min.js';
+import * as TDx from './3DconnexionJS/3dconnexion.module.min.js';
 const timeline=document.getElementById('timeline');
 for(let i=0;i<100;i++){const s=document.createElement('span');s.textContent=i;timeline.appendChild(s);} 
 let scale=1;


### PR DESCRIPTION
## Summary
- fix import syntax for `3dconnexion.module.min.js`

## Testing
- `xmllint --noout knob.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ca6a8e58832092c388fe8bd8488d