### PR TITLE
Fix module usage in demos

### DIFF
--- a/knob.html
+++ b/knob.html
@@ -14,7 +14,7 @@
 <body>
 <div id="knob"><div id="pointer"></div></div>
 <script type="module">
-import * as TDx from './3DconnexionJS/3dconnexion.module.min.js';
+import _3Dconnexion from './3DconnexionJS/3dconnexion.module.min.js';
 const pointer=document.getElementById('pointer');
 let rotation=0;
 const model={
@@ -27,7 +27,7 @@ const model={
     mouse.create3dmouse(document.body,'Knob Demo');
   }
 };
-const mouse=new TDx._3Dconnexion(model);
+const mouse=new _3Dconnexion(model);
 mouse.connect();
 </script>
 </body>

--- a/scroll.html
+++ b/scroll.html
@@ -18,7 +18,7 @@
   <p style="margin-top:150vh">End of the content.</p>
 </div>
 <script type="module">
-import * as TDx from './3DconnexionJS/3dconnexion.module.min.js';
+import _3Dconnexion from './3DconnexionJS/3dconnexion.module.min.js';
 const model={
   setViewMatrix(data){
     const dy=data[13];
@@ -28,7 +28,7 @@ const model={
     mouse.create3dmouse(document.body,'Scroll Demo');
   }
 };
-const mouse=new TDx._3Dconnexion(model);
+const mouse=new _3Dconnexion(model);
 mouse.connect();
 </script>
 </body>

--- a/timeline.html
+++ b/timeline.html
@@ -17,7 +17,7 @@
   <div id="timeline"></div>
 </div>
 <script type="module">
-import * as TDx from './3DconnexionJS/3dconnexion.module.min.js';
+import _3Dconnexion from './3DconnexionJS/3dconnexion.module.min.js';
 const timeline=document.getElementById('timeline');
 for(let i=0;i<100;i++){const s=document.createElement('span');s.textContent=i;timeline.appendChild(s);} 
 let scale=1;
@@ -33,7 +33,7 @@ const model={
     mouse.create3dmouse(timeline,'Timeline Demo');
   }
 };
-const mouse=new TDx._3Dconnexion(model);
+const mouse=new _3Dconnexion(model);
 mouse.connect();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- use default export for 3DconnexionJS module

## Testing
- `node -e "console.log('no tests')"`


------
https://chatgpt.com/codex/tasks/task_e_6840d029ffe48320a37aed1381efd0aa